### PR TITLE
Added onFun for TypedReceive on unions as shortcut when not  partial …

### DIFF
--- a/core/src/main/scala/de/knutwalker/akka/typed/TypedActor.scala
+++ b/core/src/main/scala/de/knutwalker/akka/typed/TypedActor.scala
@@ -201,6 +201,7 @@ object TypedActor {
       val pf = new TypedReceiver[A](f).asInstanceOf[PartialFunction[U, Unit]]
       new MkPartialUnionReceive[U, MkPartialUnionReceive.NonEmpty](Some(finalPf.fold(pf)(_ orElse pf)))
     }
+    def onFun[A](f: A => Unit)(implicit ev: A isPartOf U): MkPartialUnionReceive[U, MkPartialUnionReceive.NonEmpty] = on(PartialFunction(f))
 
     /** Returns the final receive function */
     implicit def apply(implicit ev: S =:= MkPartialUnionReceive.NonEmpty): PartialFunction[U, Unit] =
@@ -224,6 +225,7 @@ object TypedActor {
     /** Adds a case to the final receive function */
     def on[A](f: PartialFunction[A, Unit])(implicit ev: A isPartOf U): MkTotalUnionReceiveHalfEmpty[U, A] =
       new MkTotalUnionReceiveHalfEmpty[U, A](new TypedReceiver[A](f).asInstanceOf[PartialFunction[U, Unit]])
+    def onFun[A](f: A => Unit)(implicit ev: A isPartOf U): MkTotalUnionReceiveHalfEmpty[U, A] = on(PartialFunction(f))
   }
 
   /**
@@ -243,6 +245,7 @@ object TypedActor {
       val pf = new TypedReceiver[A](f).asInstanceOf[PartialFunction[U, Unit]]
       new MkTotalUnionReceive[U, B | A](finalPf orElse pf)
     }
+    def onFun[A](f: A => Unit)(implicit ev: A isPartOf U): MkTotalUnionReceive[U, B | A] = on[A](PartialFunction(f))
   }
 
   /**
@@ -262,6 +265,7 @@ object TypedActor {
       val pf = new TypedReceiver[A](f).asInstanceOf[PartialFunction[U, Unit]]
       new MkTotalUnionReceive[U, T | A](finalPf orElse pf)
     }
+    def onFun[A](f: A => Unit)(implicit ev: A isPartOf U): MkTotalUnionReceive[U, T | A] = on(PartialFunction(f))
 
     /** Returns the final receive function */
     implicit def apply(implicit ev: T containsAllOf U): PartialFunction[U, Unit] =

--- a/docs/src/tut/typed-actor.md
+++ b/docs/src/tut/typed-actor.md
@@ -165,6 +165,18 @@ class MyActor extends TypedActor.Of[Foo | Bar | Baz] {
 }
 ```
 
+Or if you have a full function for the cases, there is a shortcut:
+
+```tut
+class MyActor extends TypedActor.Of[Foo | Bar | Baz] {
+  def typedReceive: TypedReceive = Union
+    .onFun[Foo]{ foo ⇒ println(s"received a Foo: $foo.foo") }
+    .onFun[Bar]{ bar ⇒ println(s"received a Bar: $bar.bar") }
+    .onFun[Baz]{ baz ⇒ println(s"received a Baz: $baz.baz") }
+    .apply
+}
+```
+
 You have to provide at least one case, you cannot define an empty behavior.
 
 ```tut:fail


### PR DESCRIPTION
Proposed onFun in addition to Union.on. I am not sure if the name/implementation is right, but it works.
