### PR TITLE
Support retagging of a union typed actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,29 @@ scala> ref ! SomeOtherMessage
 As you can see, there are no wrappers involved. When you send the message, the compiler checks that the message you want to send is part of the union and if this checks succeeds, the compiler will allow the call to `!` (by not failing to compile).
 Since there can be no runtime value of the union type, there is a clear distinction for the dispatch to the check if the message itself is the specified type or a subtype thereof and the check if the message is part of the specified union type.
 
+You can turn an actor that accepts an union type into of its subcases with `only`:
+
+```scala
+scala> ref.only[Foo]
+res4: de.knutwalker.akka.typed.package.ActorRef[Foo] = Actor[akka://foo/user/my-actor#310685349]
+
+scala> ref.only[Bar]
+res5: de.knutwalker.akka.typed.package.ActorRef[Bar] = Actor[akka://foo/user/my-actor#310685349]
+
+scala> ref.only[Baz]
+res6: de.knutwalker.akka.typed.package.ActorRef[Baz] = Actor[akka://foo/user/my-actor#310685349]
+```
+
+Which checks the untion type as well.
+
+```scala
+scala> ref.only[SomeOtherMessage]
+<console>:31: error: not found: type SomeOtherMessage
+       ref.only[SomeOtherMessage]
+                ^
+```
+
+
 Union types will return later; for now, the next part is to learn how to interact with the less safer parts of Akka.
 
 

--- a/core/src/main/scala/de/knutwalker/akka/typed/package.scala
+++ b/core/src/main/scala/de/knutwalker/akka/typed/package.scala
@@ -377,6 +377,10 @@ package object typed {
       */
     def ?[A, B](f: ActorRef[B] ⇒ A)(implicit ev: A isPartOf U, timeout: Timeout, ctA: ClassTag[A], sender: UntypedActorRef = Actor.noSender): Future[B] =
       AskSupport.ask[A, B](retag(ref), f, timeout, ctA, sender)
+
+    /** Returns an ActorRef that only handles a subpart of the given union type. */
+    def only[A](implicit ev: A isPartOf U): ActorRef[A] =
+      retag(ref)
   }
 
   implicit final class UntypedPropsOps(val untyped: UntypedProps) extends AnyVal {

--- a/docs/src/tut/union.md
+++ b/docs/src/tut/union.md
@@ -94,6 +94,21 @@ ref ! SomeOtherMessage
 As you can see, there are no wrappers involved. When you send the message, the compiler checks that the message you want to send is part of the union and if this checks succeeds, the compiler will allow the call to `!` (by not failing to compile).
 Since there can be no runtime value of the union type, there is a clear distinction for the dispatch to the check if the message itself is the specified type or a subtype thereof and the check if the message is part of the specified union type.
 
+You can turn an actor that accepts an union type into of its subcases with `only`:
+
+```tut
+ref.only[Foo]
+ref.only[Bar]
+ref.only[Baz]
+```
+
+Which checks the untion type as well.
+
+```tut:fail
+ref.only[SomeOtherMessage]
+```
+
+
 Union types will return later; for now, the next part is to learn how to interact with the less safer parts of Akka.
 
 ##### [&raquo; Unsafe Usage](unsafe.html)

--- a/tests/src/test/scala/de/knutwalker/akka/typed/UnionSpec.scala
+++ b/tests/src/test/scala/de/knutwalker/akka/typed/UnionSpec.scala
@@ -81,6 +81,26 @@ object UnionSpec extends Specification with AfterAll {
       implicit val timeout: Timeout = (100 * ee.timeFactor).millis
       (ref ? Baz("foo")) must be_==(SomeOtherMessage("foo")).await
     }
+
+    "support retagging to a different type" >> {
+
+      "if it is a subtype of the defined union" >> {
+        ref.only[Foo] ! Foo("foo")
+        inbox.receive(1.second) === Foo("Bernd: foo")
+      }
+
+      "which disables all other subcases" >> {
+        typecheck {
+          """ ref.only[Foo] ! Bar """
+        } must not succeed
+      }
+
+      "fails if the type is unrelated" >> {
+        typecheck {
+          """ ref.only[SomeOtherMessage] ! Bar """
+        } must not succeed
+      }
+    }
   }
 
   "A unioned TypedActor" should {


### PR DESCRIPTION
works around invariance, as `ActorRef[A | B] <: ActorRef[A]` but don't want to make ActorRef contravariant
